### PR TITLE
Reconnects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,18 @@ language: node_js
 node_js:
   - 7
   - 8
+  - 9
 services:
   - docker
 before_script:
-  - docker run --detach -p 7419:7419 contribsys/faktory:0.6.0 -b :7419
+  - ./bin/server -d
   - |
     until nc -z -v -w30 127.0.0.1 7419
     do
       sleep 1
     done
 script:
-  - npm run lint
-  - npm test
+  - yarn lint
+  - yarn test
 after_success:
   - './node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 0.4.3 | 2017-11-12
 ---
 
- * Bufix: in the rare case a response is dropped from the server, the code was using a variable that was not defined to log the dropped message.
+ * Bugfix: in the rare case a response is dropped from the server, the code was using a variable that was not defined to log the dropped message.
 
 0.4.2 | 2017-11-12
 ---

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ See the [Faktory client for other languages](https://github.com/contribsys/fakto
 
 ## TODO
 
-- [x] Heartbea
-- [ ] Connection interrupt graceful shutdown
-- [ ] Quiet/Stop signal handling from server
-- [ ] Reconnects
+- [x] Heartbeats
+- [x] Reconnects
+- [x] Connection interrupt graceful shutdown
+- [x] Quiet/Stop signal handling from server
 - [ ] TLS
 
 ## Development

--- a/bin/server
+++ b/bin/server
@@ -7,5 +7,5 @@ docker run \
   $@ \
   -p 7419:7419 \
   -p 7420:7420 \
-  contribsys/faktory:0.6.1 \
-  -b :7419
+  contribsys/faktory:0.7.0 \
+  /faktory -b :7419

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,25 +1,35 @@
 const net = require('net');
-const utils = require('util');
 const crypto = require('crypto');
 const uuid = require('uuid/v4');
 const os = require('os');
+const assert = require('assert');
 
 const RedisParser = require('redis-parser');
 const debug = require('debug')('faktory-client');
+const serverDebug = require('debug')('faktory-client:server');
+const heartDebug = require('debug')('faktory-client:heart');
+const socketDebug = require('debug')('faktory-client:socket');
 
+const SOCKET_TIMEOUT = 20000;
+const RECONNECT_DELAY = 2000;
+const RECONNECT_LIMIT = 2;
 const FAKTORY_PROTOCOL_VERSION = 2;
 const FAKTORY_PROVIDER = process.env.FAKTORY_PROVIDER || 'FAKTORY_URL';
-const FAKTORY_URL = process.env[FAKTORY_PROVIDER] || '';
-const [FAKTORY_HOST, FAKTORY_PORT] = FAKTORY_URL.split(':');
+const FAKTORY_URL = process.env[FAKTORY_PROVIDER] || 'localhost:7419';
 
 module.exports = class Client {
   constructor(options = {}) {
     this.password = options.password;
     this.labels = options.labels || [];
     this.wid = options.wid;
-    this.queue = [];
-    this.host = options.host || FAKTORY_HOST || 'localhost';
-    this.port = options.port || FAKTORY_PORT || 7419;
+    this.reconnectLimit = options.reconnectLimit || RECONNECT_LIMIT;
+    this.reconnectDelay = options.reconnectDelay || RECONNECT_DELAY;
+    this.reconnectAttempts = 0;
+    this.replyQueue = [];
+    this.createSocket();
+    const [host, port] = (options.url || FAKTORY_URL).replace(/^(\w+:)?\/\//i, '').split(':');
+    this.host = options.host || host;
+    this.port = options.port || port || '7419';
   }
 
   static checkVersion(version) {
@@ -53,32 +63,59 @@ module.exports = class Client {
       .createHash('sha256')
       .update(pwd + salt);
 
-    if (iterations > 1) {
-      for (let i = 1; i < iterations; i += 1) {
-        hash = crypto
-          .createHash('sha256')
-          .update(hash.digest());
-      }
+    for (let i = 1; i < iterations; i += 1) {
+      hash = crypto.createHash('sha256').update(hash.digest());
     }
+
     return hash.digest('hex');
   }
 
-  connect() {
-    if (this.connected) {
-      return Promise.resolve(this);
-    }
+  static encode(command) {
+    return command.map((item) => {
+      if (typeof item !== 'string') {
+        return JSON.stringify(item);
+      }
+      return item;
+    }).join(' ');
+  }
 
+  connect() {
     debug('Connecting to server');
 
-    return new Promise((resolve) => {
-      this.socket = net.createConnection(this.port, this.host, async () => {
-        this.connected = true;
-        debug('Connected');
-        this.listen();
-        await this.handshake();
-        resolve(this);
-      });
-      this.socket.setTimeout(30000);
+    this.connecting = true;
+    return new Promise((resolve, reject) => {
+      this.onConnectResolve = resolve;
+      this.onConnectReject = reject;
+      this._connect();
+    });
+  }
+
+  _connect() {
+    this.socket.connect(this.port, this.host);
+  }
+
+  listenToSocket() {
+    this.socket
+      .on('connect', this.onConnect.bind(this))
+      .on('data', buffer => this.parser.execute(buffer))
+      .on('close', this.onClose.bind(this))
+      .on('timeout', /* istanbul ignore next */ () => {
+        socketDebug('Connection timed out');
+      })
+      .on('error', this.onError.bind(this));
+
+    return this;
+  }
+
+  createParser() {
+    return new RedisParser({
+      returnReply: this.receive.bind(this),
+      returnError: this.receiveError.bind(this),
+      returnFatalError: /* istanbul ignore next */ (err) => {
+        console.error('Connection fatal error', err);
+        this.close();
+        throw err;
+      }
     });
   }
 
@@ -92,12 +129,11 @@ module.exports = class Client {
         }
 
         Client.checkVersion(greeting.v);
-
         const hello = this.buildHello(greeting);
         return resolve(await this.send(['HELLO', hello], 'OK'));
       };
 
-      this.queue.push({ callback: sayHello });
+      this.replyQueue.push(sayHello);
     });
   }
 
@@ -120,75 +156,50 @@ module.exports = class Client {
     return hello;
   }
 
-  createParser() {
-    return new RedisParser({
-      returnReply: this.receive.bind(this),
-      returnError: this.receiveError.bind(this),
-      returnFatalError: /* istanbul ignore next */ (err) => {
-        this.shutdown();
-        throw err;
-      }
-    });
+  async send(command, expectation) {
+    if (!this.socket.writable) {
+      throw new Error('Socket not writable');
+    }
+    const encodedCommand = Client.encode(command);
+    const response = await this._send(encodedCommand);
+
+    debug('client=%o, server=%o', encodedCommand, response);
+
+    if (expectation && response && response.text) {
+      assert.equal(
+        response.text,
+        expectation,
+        `Expected ${expectation} from server, but got ${response.text}`
+      );
+    }
+
+    return response;
   }
 
-  listen() {
-    const parser = this.createParser();
-
-    this.socket
-      .on('data', buffer => parser.execute(buffer))
-      .on('close', () => {
-        debug('Connection closed');
-        this.connected = false;
-      })
-      .on('timeout', /* istanbul ignore next */ () => {
-        debug('Connection timed out');
-        this.shutdown();
-      })
-      .on('error', /* istanbul ignore next */ e => console.error(e));
-
-    return this;
-  }
-
-  send(command, expectation) {
-    const encoded = command.map((item) => {
-      if ({}.toString.call(item) === '[object Object]') {
-        return JSON.stringify(item);
-      }
-      return item;
-    });
-
+  _send(encodedCommand) {
     return new Promise((resolve, reject) => {
-      const commandString = encoded.join(' ');
-
-      debug(`SEND: ${commandString}`);
-      this.socket.write(`${commandString}\r\n`);
-
-      this.queue.push({
-        command,
-        callback: (err, resp) => {
-          if (err) {
-            return reject(err);
-          } else if (expectation && resp.text !== expectation) {
-            return reject(new Error(`Expected response: ${expectation}, got: ${resp.text}`));
-          }
-          debug(`SENT: ${command}, GOT: ${JSON.stringify(resp)}`);
-          return resolve(resp);
+      debug('%s', encodedCommand);
+      this.socket.write(`${encodedCommand}\r\n`);
+      this.replyQueue.push((err, resp) => {
+        if (err) {
+          return reject(err);
         }
+        return resolve(resp);
       });
     });
   }
 
   receive(data) {
-    debug(`RECEIVE: ${utils.inspect(data)}`);
+    serverDebug(data);
 
-    const command = this.queue.shift();
+    const callback = this.replyQueue.shift();
 
-    if (!command) {
-      throw new Error(`Queue empty. Dropped response! ${data}`);
+    if (!callback) {
+      throw new Error(`replyQueue empty. Dropped response! ${data}`);
     }
 
     if (!data) {
-      command.callback(null, data);
+      return callback(null, data);
     }
 
     let response;
@@ -202,47 +213,52 @@ module.exports = class Client {
       }
     }
 
-    command.callback(error, response);
+    return callback(error, response);
   }
 
   receiveError(err) {
-    this.queue.shift().callback(err);
+    // @TODO only shift if present, otherwise error with message
+    this.replyQueue.shift()(err);
   }
 
-  fetch(...queues) {
-    return this.send(['FETCH', ...queues]).then(res => res && res.payload);
+  async fetch(...queues) {
+    const response = await this.send(['FETCH', ...queues]);
+    return response && response.payload;
   }
 
   /**
-   * Send a heartbit for this.wid to the server
+   * Send a heartbeatt for this.wid to the server
    * @return {String|Object} string 'OK' when the heartbeat is accepted, otherwise
    *                                may return an object { state: '...' } when the
    *                                server has a signal to send this client
    */
-  beat() {
-    return this.send(['BEAT', { wid: this.wid }]).then(res => res.text || res.payload.state);
+  async beat() {
+    heartDebug('BEAT');
+    const response = await this.send(['BEAT', { wid: this.wid }]);
+    return response.text || response.payload.state;
   }
 
-  push(job) {
+  async push(job) {
     const jid = job.jid || uuid();
     const payload = Object.assign({ jid }, job);
-    return this.send(['PUSH', payload], 'OK').then(() => jid);
+    await this.send(['PUSH', payload], 'OK');
+    return jid;
   }
 
-  flush() {
-    return this.send(['FLUSH']).then(res => res.text);
+  async flush() {
+    return (await this.send(['FLUSH'])).text;
   }
 
-  info() {
-    return this.send(['INFO']).then(res => res.payload);
+  async info() {
+    return (await this.send(['INFO'])).payload;
   }
 
-  ack(jid) {
-    return this.send(['ACK', { jid }], 'OK').then(res => res.text);
+  async ack(jid) {
+    return (await this.send(['ACK', { jid }], 'OK')).text;
   }
 
-  fail(jid, e) {
-    return this.send([
+  async fail(jid, e) {
+    const response = await this.send([
       'FAIL',
       {
         message: e.message,
@@ -250,18 +266,96 @@ module.exports = class Client {
         backtrace: e.stack.split('\n').slice(0, 100),
         jid
       }
-    ], 'OK').then(res => res.text);
+    ], 'OK');
+    return response.text;
   }
 
-  async close() {
-    if (!this.socket || this.socket.destroyed) {
+  close() {
+    this.closing = true;
+    if (this.socket && this.socket.writable) {
+      this.socket.write('END\r\n');
+    }
+    this.socket.end();
+    if (this.socket && !this.socket.destroyed) {
+      this.socket.destroy();
+    }
+  }
+
+  createSocket() {
+    this.socket = new net.Socket();
+    this.socket.setTimeout(SOCKET_TIMEOUT);
+    this.parser = this.createParser();
+    this.listenToSocket();
+  }
+
+  async onConnect() {
+    socketDebug('connect');
+    debug('Established connection');
+
+    try {
+      await this.handshake();
+      debug('Connected');
+      this.connecting = false;
+      this.connected = true;
+      this.reconnectAttempts = 0;
+      this.onConnectResolve(this);
+    } catch (e) {
+      this.onConnectReject(e);
+    }
+  }
+
+  onClose() {
+    socketDebug('close');
+
+    let reconnect = false;
+    this.connected = false;
+
+    this.clearReplyQueue();
+
+    if (this.closing) {
+      this.closing = false;
+      debug('Connection closed');
       return;
     }
-    this.socket.end('END\r\n');
-    this.connected = false;
+
+    debug('Connection closed unexpectedly');
+
+    reconnect = this.reconnectAttempts < this.reconnectLimit;
+    if (reconnect) {
+      this.reconnectAttempts += 1;
+      const delay = this.reconnectDelay * this.reconnectAttempts;
+      debug(`Reconnecting in ${delay / 1000}s...`);
+      setTimeout(() => {
+        if (!this.closing) {
+          this._connect();
+        }
+      }, delay);
+    } else {
+      const err = this.lastConnectionError ||
+        new Error('Unable to connect: reconnect attempts exhausted');
+      if (this.connecting) {
+        this.onConnectReject(err);
+      } else {
+        this.onError(err);
+      }
+    }
   }
 
-  async shutdown() {
-    return this.close();
+  onError(err) {
+    socketDebug('error: %o', err);
+
+    if (this.connecting) {
+      this.onConnectReject(err);
+    }
+
+    this.lastConnectionError = err;
+    console.error(err);
+    this.close();
+    // @TODO fail nosily / interrupt worker manager
+    // this.emit('error', err);
+  }
+
+  clearReplyQueue() {
+    this.replyQueue = [];
   }
 };

--- a/test/support/helper.js
+++ b/test/support/helper.js
@@ -23,7 +23,7 @@ const withConnection = async (opts, cb) => {
     throw e;
   } finally {
     debug('Shutting down client');
-    await client.shutdown();
+    await client.close();
   }
 };
 


### PR DESCRIPTION
Addresses https://github.com/jbielick/faktory_worker_node/issues/4

 * Refactor connection process: reconnect on `close`, failure before giving up. Socket will now be reconnected in the event of an unexpected close. *Timeouts are currently not handled.*
 * Add `reconnectLimit` option to restrict the number of reconnect attempts on interruption
 * Improve debug logging output (server, socket, heartbeat and more info all around)
 * Use assert module for response expectations
 * Parse connection URLs better (allow tcp://)

**`Client#shutdown` has been removed. Use `Client#close` instead.**